### PR TITLE
Use https instead of git@ for cloning submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vwifi"]
 	path = vwifi
-	url = git@github.com:Raizo62/vwifi.git
+	url = https://github.com/Raizo62/vwifi.git


### PR DESCRIPTION
With git@, the user is requested to have a SSH key registered at Github.