### PR TITLE
Replace "hostname -I" with iproute2 method for getting IP

### DIFF
--- a/setup-vm.sh
+++ b/setup-vm.sh
@@ -4,8 +4,8 @@ PORT="${1:-}"
 [[ -n "$PORT" ]] || { echo "Usage: $0 <ssh-port>"; exit 1; }
 
 # On the host: pick the first IPv4 from `hostname -I`
-HOST_IPV4="$(hostname -I | awk '{for(i=1;i<=NF;i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/){print $i; exit}}')"
-[ -n "$HOST_IPV4" ] || { echo "Could not parse host IPv4 from hostname -I"; exit 1; }
+HOST_IPV4="$(ip -f inet address show scope global | grep -Po 'inet \K[\d.]+' | tail -n 1)"
+[ -n "$HOST_IPV4" ] || { echo "Could not parse host IPv4"; exit 1; }
 
 
 # 1) Remote setup of the VM — pass HOST_IPV4 as $1 to the remote shell

--- a/start-mesh.sh
+++ b/start-mesh.sh
@@ -14,7 +14,7 @@ VM3_IMAGE="$LIBREMESH_DIR/vm3-overlay.qcow2"
 VM_TEST="$LIBREMESH_DIR/vm-test-overlay.qcow2"
 
 # Host IP
-HOST_IP=$(hostname -I | cut -d ' ' -f1)
+HOST_IP=$(ip -f inet address show scope global | grep -Po 'inet \K[\d.]+' | tail -n 1)
 [ -n "$HOST_IP" ] || { echo "Couldn't determine the HOST_IP"; exit 1; }
 
 VWIFI_CMD="vwifi-server -u"   # pane 0


### PR DESCRIPTION
On my laptop running Arch, the hostname command does not have a `-I` option, so that the script fails with:

```
./libremesh-virtual-mesh/start-mesh.sh
hostname: invalid option -- 'I'
Try 'hostname --help' or 'hostname --usage' for more information.
```

So I used an alternative command from iproute2.
Then I took the grep part from here: https://unix.stackexchange.com/a/87470/332810
The `tail -n 1` part is not needed when computers are connected just to one network.

Please check if this works also on your computer.